### PR TITLE
評価値のfail-high、fail-low対応（ShogiGUI、将棋所）

### DIFF
--- a/Qhashima/Form1.cs
+++ b/Qhashima/Form1.cs
@@ -235,9 +235,13 @@ namespace Qhashima
                                 }
                                 else
                                 {
+                                    // fail-high、fail-low対応
+                                    string hoge = valueline.Substring(1, valueline.Length - 1);
+                                    hoge = hoge.Replace("++", "").Replace("--", "");
+
                                     int t;
-                                    if(!int.TryParse(valueline.Substring(1, valueline.Length - 1), out t)) { continue; }
-                                    value = int.Parse(valueline.Substring(1, valueline.Length - 1));
+                                    if(!int.TryParse(hoge, out t)) { continue; }
+                                    value = int.Parse(hoge);
                                 }
                             }
                         }

--- a/Qhashima/Form1.cs
+++ b/Qhashima/Form1.cs
@@ -286,6 +286,9 @@ namespace Qhashima
                                 }
                                 else
                                 {
+                                    // fail-high、fail-low対応
+                                    hoge = hoge.Replace("↑", "").Replace("↓", "");
+
                                     int t;
                                     if (!int.TryParse(hoge, out t)) { value = 0;  continue; }
                                     value = int.Parse(hoge);


### PR DESCRIPTION
Qhashimaの公開ありがとうございます。
ShogiGUIの評価値「123↑」「456↓」などが一律0に変換されてしまっているようでしたので、
Form1.csに1行だけ追加してみました。